### PR TITLE
Fix blank line at start of service file

### DIFF
--- a/dist/steamtricksd.service
+++ b/dist/steamtricksd.service
@@ -6,7 +6,7 @@
 # - run `systemctl --user daemon-reload` to refresh systemd
 # - run `systemctl --user restart steamtricksd` and so on
 #
-
+#
 [Unit]
 Description=steamtricks daemon
 


### PR DESCRIPTION
Better fix for [PATCH](https://build.opensuse.org/package/view_file/home:gmbr3:Steam/steamtricks/remove-line-in-service.patch?expand=1)